### PR TITLE
Update nginx version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Ira W. Snyder <isnyder@lcogt.net>
 
 EXPOSE 80
 
-ENV NGINX_VERSION=1.9.5
+ENV NGINX_VERSION=1.13.0
 
 # install system packages
 RUN yum -y install epel-release \

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,11 +20,6 @@ http {
     access_log /dev/stdout;
     error_log  /dev/stdout;
 
-    gzip on;
-    gzip_disable "msie6";
-    gzip_http_version 1.1;
-    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-
     # This server is used internally by mod_zip to access the file content
     # which is stored on S3.
     server {


### PR DESCRIPTION
From the [mod_zip docs](https://github.com/evanmiller/mod_zip#installation):

> nginx 1.10.0 or later is required

This project wasn't working for me and it took a little while for me to notice the version constraint. Updating to 1.13.0 seems to have made things work for me.