### PR TITLE
Use the old branch of ngx_aws_auth and added more info for newbies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Ira W. Snyder <isnyder@lcogt.net>
 
 EXPOSE 80
 
-ENV NGINX_VERSION=1.13.0
+ENV NGINX_VERSION=1.15.8
 
 # install system packages
 RUN yum -y install epel-release \
@@ -22,7 +22,7 @@ RUN yum -y install epel-release \
 RUN curl -LO http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
         && tar zxf nginx-${NGINX_VERSION}.tar.gz \
         && cd nginx-${NGINX_VERSION} \
-        && git clone https://github.com/anomalizer/ngx_aws_auth.git \
+        && git clone --single-branch --branch AuthV2 https://github.com/anomalizer/ngx_aws_auth.git \
         && git clone https://github.com/evanmiller/mod_zip.git \
         && ./configure \
             --prefix=/usr \

--- a/README.md
+++ b/README.md
@@ -38,23 +38,42 @@ optional. **DO NOT FORGET THE `/s3/` PREFIX ON THE FILE NAMES!!!**
     - 1234 /s3/test1.txt test1.txt
     - 5678 /s3/test2.txt test2.txt
 
+Create a new directory `example` and save the file in `example/test.txt`.
+
 Now we run the Docker container on TCP port 8888, and bind mount our example
-file inside the container at `/var/www/html/example.txt`. We also specify the
+directory inside the container at `/var/www/html/example/`. We also specify the
 Amazon Web Services S3 credentials.
 
+```bash
     docker run -p 8888:80 \
         -v example:/var/www/html/example \
-        -e 'AWS_ACCESS_KEY_ID=" \
-        -e 'AWS_SECRET_ACCESS_KEY=" \
-        -e 'AWS_DEFAULT_REGION=" \
-        -e 'AWS_BUCKET=" \
+        -e 'AWS_ACCESS_KEY_ID=' \
+        -e 'AWS_SECRET_ACCESS_KEY=' \
+        -e 'AWS_DEFAULT_REGION=' \
+        -e 'AWS_BUCKET=' \
         nginx_s3_streaming_zip
+```
 
 And now you can visit the page with cURL (or with the web browser of your choice):
 
-    curl -v -XGET 'http://localhost:8888/example' > example.zip
+    curl -v -XGET 'http://localhost:8888/example/test.txt' > example.zip
 
 You will have a valid ZIP file containing the files you asked for!
+
+How does it work?
+===================
+The `nginx.conf` has several configurations.
+
+The main server listening on port `80` directs all the requests depending on:
+
+* All paths matching `^/s3/(?<url>.*)$` (the /s3/ files) will be redirected to the server listening on port `3333`: `http://127.0.0.1:3333/$url`. This server will be our proxy to `S3` files.
+* Everything else is handled by the server running on port `8080`: `http://127.0.0.1:8080`.
+
+When the request for `/example/test.txt` arrives, it will be handled by the server running on port `8080`. It will add a header:
+
+    add_header X-Archive-Files 'zip';
+
+which triggers the `mod_zip`. As a result, the content of `example/test.txt` will be parsed by `mod_zip` to generate a zip file on the fly. Now this is where the proxy to `S3` on port `3333` kicks in. Remeber that the `S3` files in `test.txt` had a prefix `/s3/`. This will cause the internal reads to `/s3/test1.txt` to be handled by the proxy and directed to `https://<bucket>.s3.amazonaws.com/test1.txt`.
 
 License Information
 ===================


### PR DESCRIPTION
The demo is meant to be used with the older branch of `ngx_aws_auth`, `AuthV2`. I also added more info for newbies.
